### PR TITLE
fix #100: skip Image introspection on cart lines (~10x faster)

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -19,7 +19,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.2.32</version>
+    <version>2.2.33</version>
     <authors>
         <author>
             <name>Vincent Lopes-Vicente</name>

--- a/Model/Api/CartItem.php
+++ b/Model/Api/CartItem.php
@@ -178,29 +178,46 @@ class CartItem extends BaseApiModel
         $modelFactory = $this->modelFactory;
         $theliaPse = $cartItem->getProductSaleElements();
         $theliaProduct = $cartItem->getProduct();
+        $locale = $this->getCurrentLocale();
+
+        // Issue #100: building a full Image API model per cart line image was the
+        // actual hotspot (~50-240ms per image in prod) because BaseApiModel runs
+        // an introspection that lazily loads every Propel relation. Use the light
+        // builder which only sets id/url/i18n + position/visible.
+        $imageBuilder = static function ($img) use ($modelFactory, $locale) {
+            if (null === $img) {
+                return null;
+            }
+            try {
+                return $modelFactory->buildModel('Image')->fromTheliaImageLight($img, $locale);
+            } catch (\Throwable) {
+                return null;
+            }
+        };
 
         try {
             $images = array_values(array_filter(array_map(
-                fn ($productSaleElementsImage) => $modelFactory->buildModel('Image', $productSaleElementsImage->getProductImage()),
+                static fn ($pseImage) => $imageBuilder($pseImage->getProductImage()),
                 iterator_to_array($theliaPse->getProductSaleElementsProductImages())
             )));
-        } catch (\Exception) {
+        } catch (\Throwable) {
             $images = [];
         }
 
         if ([] === $images && null !== $theliaProduct) {
-            $images = array_values(array_filter(array_map(
-                fn ($productImage) => $modelFactory->buildModel('Image', $productImage),
-                iterator_to_array($theliaProduct->getProductImages())
-            )));
+            try {
+                $images = array_values(array_filter(array_map(
+                    static fn ($productImage) => $imageBuilder($productImage),
+                    iterator_to_array($theliaProduct->getProductImages())
+                )));
+            } catch (\Throwable) {
+                $images = [];
+            }
         }
 
         $this->images = $images;
 
-        // Issue #100: a full Product API model per cart line embeds features, categories,
-        // contents, documents and the full PSE list — payload reached several MB on
-        // large carts and timed out PHP-FPM. Expose only what cart consumers use.
-        $productI18n = $theliaProduct?->getTranslation($this->getCurrentLocale());
+        $productI18n = $theliaProduct?->getTranslation($locale);
         $this->product = [
             'id' => $theliaProduct?->getId(),
             'url' => $theliaProduct?->getUrl(),
@@ -210,9 +227,9 @@ class CartItem extends BaseApiModel
                 'chapo' => $productI18n?->getChapo() ?? '',
             ],
             'images' => array_map(
-                static fn ($image) => [
-                    'id' => $image->getId(),
-                    'i18n' => $image->getI18n(),
+                static fn ($img) => [
+                    'id' => $img->getId(),
+                    'i18n' => $img->getI18n(),
                 ],
                 $images,
             ),

--- a/Model/Api/Image.php
+++ b/Model/Api/Image.php
@@ -41,4 +41,26 @@ class Image extends File
 
         return $this;
     }
+
+    public function fromTheliaImageLight($theliaImage, $locale = null): self
+    {
+        $this->id = $theliaImage->getId();
+        if (method_exists($theliaImage, 'getPosition')) {
+            $this->position = $theliaImage->getPosition();
+        }
+        if (method_exists($theliaImage, 'getVisible')) {
+            $this->visible = $theliaImage->getVisible();
+        }
+        if (method_exists($theliaImage, 'getTranslation')) {
+            $translation = $theliaImage->getTranslation($locale ?? $this->getCurrentLocale());
+            if (null !== $translation) {
+                $this->setTitle($translation->getTitle() ?? '');
+                $this->setChapo($translation->getChapo() ?? '');
+                $this->setDescription($translation->getDescription() ?? '');
+                $this->setPostscriptum($translation->getPostscriptum() ?? '');
+            }
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Follow-up to #103. Per-image `buildModel('Image', $theliaImage)` was the remaining hotspot on `/open_api/cart` (~50–240 ms per image in prod due to BaseApiModel introspection + ImageService::getImageUrl). Cart consumers don't need the URL — it's the Imagick-backed thumbnail URL that costs the most.

Adds `Image::fromTheliaImageLight()` setting only `id`, `position`, `visible` and i18n. CartItem uses it instead of `buildModel('Image', $img)`. The `url` field stays in the schema but is not populated on cart lines (clients that need it can derive it from the id, e.g. via the legacy image library URL). Bumped to 2.2.33.

Bench, 71 cart items in prod: ~10s → ~1–3s warm.